### PR TITLE
Update command.py

### DIFF
--- a/vkquick/chatbot/command/command.py
+++ b/vkquick/chatbot/command/command.py
@@ -199,7 +199,9 @@ class Command(HandlerMixin[Handler]):
         # или аргументов не должно быть вовсе
         if self._text_arguments and summary_regex:
             summary_regex += r"(?:$|\s+)"
-
+        else:
+            summary_regex += r"$"
+            
         self._routing_regex = re.compile(
             summary_regex,
             flags=self.routing_re_flags,


### PR DESCRIPTION
Bug fix. When there are several names, one of which is completely at the beginning of another name, then the derived name (longer) will not work. (for example, "nam" and "name" - "name" will not be listened to by the handler.